### PR TITLE
Move jupiterone.md file so support docs are auto-generated #38

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -3,7 +3,8 @@
 ## Threat Stack + JupiterOne Integration Benefits
 
 - Visualize Threat Stack agents in the JupiterOne graph.
-- Map Threat Stack agents to aws instances or servers they protect in your JupiterOne account.
+- Map Threat Stack agents to aws instances or servers they protect in your
+  JupiterOne account.
 - Map Threat Stack agents to cves they identify in your JupiterOne
 - Monitor changes to Threat Stack agents using JupiterOne alerts.
 
@@ -15,8 +16,9 @@
 
 ## Requirements
 
-- JupiterOne requires the name and id of your Threat Stack organization. JupiterOne also 
-requires the user id and API key of a configured application key.
+- JupiterOne requires the name and id of your Threat Stack organization.
+  JupiterOne also requires the user id and API key of a configured application
+  key.
 - You must have permission in JupiterOne to install new integrations.
 
 ## Support
@@ -28,12 +30,12 @@ If you need help with this integration, please contact
 
 ### In Threat Stack
 
-The integration instance configuration requires the following parameters for 
-API authentication:
+The integration instance configuration requires the following parameters for API
+authentication:
 
 Go to **Settings > Application Keys** from the web console of your Threat Stack
-account, then find the following values under **REST API Key**, copy/paste
-each of them into your integration configuration screen in JupiterOne.
+account, then find the following values under **REST API Key**, copy/paste each
+of them into your integration configuration screen in JupiterOne.
 
 - **Organization Name** (`orgName`)
 - **Organization ID** (`orgId`)
@@ -45,17 +47,19 @@ each of them into your integration configuration screen in JupiterOne.
 1. From the configuration **Gear Icon**, select **Integrations**.
 2. Scroll to the **Threat Stack** integration tile and click it.
 3. Click the **Add Configuration** button and configure the following settings:
+
 - Enter the **Account Name** by which you'd like to identify this Threat Stack
-   account in JupiterOne. Ingested entities will have this value stored in
-   `tag.AccountName` when **Tag with Account Name** is checked.
+  account in JupiterOne. Ingested entities will have this value stored in
+  `tag.AccountName` when **Tag with Account Name** is checked.
 - Enter a **Description** that will further assist your team when identifying
-   the integration instance.
+  the integration instance.
 - Select a **Polling Interval** that you feel is sufficient for your monitoring
-   needs. You may leave this as `DISABLED` and manually execute the integration.
+  needs. You may leave this as `DISABLED` and manually execute the integration.
 - Enter the **Organization Name** of your Threat Stack account.
 - Enter the **Organization ID** of your Threat Stack account.
 - Enter the **User ID** configured for API access.
 - Enter the **API Key** configured for API access.
+
 4. Click **Create Configuration** once all values are provided.
 
 ## How to Uninstall

--- a/tools/docs.ts
+++ b/tools/docs.ts
@@ -2,7 +2,7 @@ import fs from "fs-extra";
 
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
 
-const baseDocsPath = `docs/jupiterone-io/index`;
+const baseDocsPath = `docs/jupiterone`;
 
 let docsExtension;
 if (fs.pathExistsSync(`${baseDocsPath}.md`)) {


### PR DESCRIPTION
The `docs` project is printing
```
Could not fetch documentation file for project graph-threatstack
```
because this path name was wrong.